### PR TITLE
Fix timer implementation

### DIFF
--- a/source/timer.cpp
+++ b/source/timer.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2014 ARM. All rights reserved.
  */
 #include "mbed.h"
+#include "us_ticker_api.h"
 
 extern "C" {
 #include "nanostack-event-loop/platform/arm_hal_timer.h"


### PR DESCRIPTION
The recent low power timer code changed various headers, making the
code in source/timer.cpp invalid because "us_ticker_api.h" was no
longer included.
