### PR TITLE
fix compilation with armcc

### DIFF
--- a/source/timer.cpp
+++ b/source/timer.cpp
@@ -31,7 +31,7 @@ void platform_timer_enable(void)
  * \param new_fp Function pointer for stack giving timer handler
  *
  */
-void platform_timer_set_cb(void (*new_fp)(void))
+void platform_timer_set_cb(platform_timer_cb new_fp)
 {
     sn_callback = new_fp;
 }


### PR DESCRIPTION
It's necessary to use a typedef for a function pointer-type argument of an
extern-C function, otherwise extern-c is not correctly applied to the
argument's type, resulting in a linker error.
