### PR TITLE
Update mbedOS event handling

### DIFF
--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "mbed-drivers": "<1.0.0",
     "nanostack-libservice": "^3.0.0",
-    "sal-stack-nanostack-eventloop": "^1.0.0"
+    "sal-stack-nanostack-eventloop": "^1.0.4"
   },
   "targetDependencies": {}
 }


### PR DESCRIPTION
-Moved mbedOS event handling to adaptor from eventloop.
-Removed unnecessary methods (idle, wait, sleep) as they are not needed
 in mbedOS port.

@kjbracey-arm , would you please review?